### PR TITLE
[In Progress] Port to TelepathyGlib

### DIFF
--- a/SearchActivity.py
+++ b/SearchActivity.py
@@ -11,7 +11,9 @@
 
 import gi
 gi.require_version('Gtk', '3.0')
+gi.require_version('TelepathyGLib', '0.12')
 from gi.repository import Gtk, Gdk
+from gi.repository import TelepathyGLib
 
 from sugar3.activity import activity
 from sugar3 import profile
@@ -22,7 +24,6 @@ from sugar3.activity.widgets import StopButton
 from toolbar_utils import button_factory, label_factory, separator_factory
 from utils import json_load, json_dump, convert_seconds_to_minutes
 
-import telepathy
 import dbus
 from dbus.service import signal
 from dbus.gobject_service import ExportedGObject
@@ -44,6 +45,8 @@ _logger = logging.getLogger('cookie-search-activity')
 
 SERVICE = 'org.sugarlabs.CookieSearchActivity'
 IFACE = SERVICE
+
+PATH = '/org/sugarlabs/CookieSearchActivity'
 
 
 class SearchActivity(activity.Activity):
@@ -206,28 +209,28 @@ class SearchActivity(activity.Activity):
 
     def _new_tube_common(self, sharer):
         """ Joining and sharing are mostly the same... """
-        if self._shared_activity is None:
+        if self.get_shared_activity() is None:
             _logger.debug("Error: Failed to share or join activity ... \
-                _shared_activity is null in _shared_cb()")
+                get_shared_activity() is null in _shared_cb()")
             return
 
         self.initiating = sharer
         self.waiting_for_hand = not sharer
 
-        self.conn = self._shared_activity.telepathy_conn
-        self.tubes_chan = self._shared_activity.telepathy_tubes_chan
-        self.text_chan = self._shared_activity.telepathy_text_chan
+        self.conn = self.get_shared_activity().telepathy_conn
+        self.tubes_chan = self.get_shared_activity().telepathy_tubes_chan
+        self.text_chan = self.get_shared_activity().telepathy_text_chan
 
-        self.tubes_chan[telepathy.CHANNEL_TYPE_TUBES].connect_to_signal(
+        self.tubes_chan[TelepathyGLib.IFACE_CHANNEL_TYPE_TUBES].connect_to_signal(
             'NewTube', self._new_tube_cb)
 
         if sharer:
             _logger.debug('This is my activity: making a tube...')
-            id = self.tubes_chan[telepathy.CHANNEL_TYPE_TUBES].OfferDBusTube(
+            id = self.tubes_chan[TelepathyGLib.IFACE_CHANNEL_TYPE_TUBES].OfferDBusTube(
                 SERVICE, {})
         else:
             _logger.debug('I am joining an activity: waiting for a tube...')
-            self.tubes_chan[telepathy.CHANNEL_TYPE_TUBES].ListTubes(
+            self.tubes_chan[TelepathyGLib.IFACE_CHANNEL_TYPE_TUBES].ListTubes(
                 reply_handler=self._list_tubes_reply_cb,
                 error_handler=self._list_tubes_error_cb)
         self._game.set_sharing(True)
@@ -246,16 +249,16 @@ class SearchActivity(activity.Activity):
         _logger.debug('New tube: ID=%d initator=%d type=%d service=%s \
 params=%r state=%d' % (id, initiator, type, service, params, state))
 
-        if (type == telepathy.TUBE_TYPE_DBUS and service == SERVICE):
-            if state == telepathy.TUBE_STATE_LOCAL_PENDING:
+        if (type == TelepathyGLib.TubeType.DBUS and service == SERVICE):
+            if state == TelepathyGLib.TubeState.LOCAL_PENDING:
                 self.tubes_chan[
-                    telepathy.CHANNEL_TYPE_TUBES].AcceptDBusTube(id)
+                    TelepathyGLib.IFACE_CHANNEL_TYPE_TUBES].AcceptDBusTube(id)
 
             tube_conn = TubeConnection(
                 self.conn, self.tubes_chan[
-                    telepathy.CHANNEL_TYPE_TUBES], id,
+                    TelepathyGLib.IFACE_CHANNEL_TYPE_TUBES], id,
                 group_iface=self.text_chan[
-                    telepathy.CHANNEL_INTERFACE_GROUP])
+                    TelepathyGLib.IFACE_CHANNEL_INTERFACE_GROUP])
 
             self.chattube = ChatTube(tube_conn, self.initiating,
                                      self.event_received_cb)


### PR DESCRIPTION
### Explanation
Fixes #13. This PR ports to TelepathyGLib. 

### Reason
The telepathy library does not have its bindings for Python 3, and porting Telepathy to its PyGObject binding is a pre requisite for the Port to Python 3 Project.

### Test result
No error related to the port to TelepathyGLib.
```
tonadev@TDPC:~/Documents/Work/OpenSource/code_in/sugarlabs/cookie-search-activity$ sugar-activity

(sugar-activity:9813): Gtk-WARNING **: 13:31:59.407: Theme parsing error: gtk-widgets.css:16:32: The style property GtkExpander:expander-size is deprecated and shouldn't be used anymore. It will be removed in a future version

(sugar-activity:9813): Gtk-WARNING **: 13:31:59.407: Theme parsing error: gtk-widgets.css:17:35: The style property GtkExpander:expander-spacing is deprecated and shouldn't be used anymore. It will be removed in a future version

```
